### PR TITLE
Switching to JSONPath-Plus

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "date-fns": "^2.16.1",
-    "jsonpath": "^1.0.2",
+    "jsonpath-plus": "^4.0.0",
     "memory-cache": "^0.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7252,6 +7252,11 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonpath-plus@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-4.0.0.tgz#954b69faa3d8b07f30ae2f9e601176a4b0d2806e"
+  integrity sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A==
+
 jsonpath@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/jsonpath/-/jsonpath-1.0.2.tgz#e6aae681d03e9a77b4651d5d96eac5fc63b1fd13"


### PR DESCRIPTION
As [promised/threatened on Twitter](https://twitter.com/foosel/status/1308339129105645571) I've looked into replacing jsonpath with [JSONPath-Plus](https://github.com/JSONPath-Plus/JSONPath) in order to get access to some more query options, namely

> * Convenient **additions or elaborations** not provided in the original spec:
>     * `^` for grabbing the **parent** of a matching item
>     * `~` for grabbing **property names** of matching items (as array)
>     * **Type selectors** for obtaining:
>         * Basic JSON types: `@null()`, `@boolean()`, `@number()`, `@string()`, `@array()`, `@object()`
>         * `@integer()`
>         * The compound type `@scalar()` (which also accepts `undefined` and
>             non-finite numbers when querying JavaScript objects as well as all of the basic non-object/non-function types)
>         * `@other()` usable in conjunction with a user-defined `otherTypeCallback`
>         * Non-JSON types that can nevertheless be used when querying
>             non-JSON JavaScript objects (`@undefined()`, `@function()`, `@nonFinite()`)
>     * `@path`/`@parent`/`@property`/`@parentProperty`/`@root` **shorthand selectors** within filters
>     * **Escaping**
>         * `` ` `` for escaping remaining sequence
>         * `@['...']`/`?@['...']` syntax for escaping special characters within
>         property names in filters
>     * Documents `$..` (**getting all parent components**)

It's actually working great, things like `$.*~` now work (endpoint is https://data.octoprint.org/export/plugin_stats_30d.json):

![firefox_2020-09-22_19-31-06](https://user-images.githubusercontent.com/83657/93917472-53c35800-fd0b-11ea-969e-480c47da8989.png)

I'm marking this as WIP however since I've encountered a small issue with the fallback field name... While the API docs of the JPP package talk about `const paths = JSONPath.toPathArray(field.jsonPath);`, I cannot for the life of me get TypeScript to not cry foul at a corresponding use. I have no idea if I'm doing something wrong here or if there's something wrong with JPP's TypeScript bindings maybe, so any hint would be greatly appreciated!

*edit* This is the error I get from `yarn dev` when I uncomment the `toPathArray` line:

```
$ yarn dev
yarn run v1.22.5
$ grafana-toolkit plugin:dev
√ Linting
- Bundling plugin in dev mode  Starting type checking service...
  Using 1 worker with 2048MB memory limit
| Bundling plugin in dev mode  ERROR in D:/Code/grafana-plugins/grafana-jsonapi-datasource/src/DataSource.ts(38,34):
  TS2339: Property 'toPathArray' does not exist on type 'JSONPathType'.
  
   Hash: 886f57ef93f391b92b96
  Version: webpack 4.41.5
  Time: 5999ms
  Built at: 2020-09-22 19:27:47
               Asset      Size  Chunks                          Chunk Names
             LICENSE  11.1 KiB          [emitted]
           README.md  1.01 KiB          [emitted]
        img/logo.svg  1.55 KiB          [emitted]
  img/screenshot.png   732 KiB          [emitted]        [big]
    img/variable.png   719 KiB          [emitted]        [big]
           module.js   962 KiB  module  [emitted]        [big]  module
       module.js.map   776 KiB  module  [emitted] [dev]         module
         plugin.json   1.2 KiB          [emitted]
  Entrypoint module [big] = module.js module.js.map
  [../node_modules/date-fns/esm/index.js] 13.2 KiB {module} [built]
  [../node_modules/jsonpath-plus/dist/index-es.js] 31.2 KiB {module} [built]
  [../node_modules/lodash/defaults.js] 1.71 KiB {module} [built]
  [../node_modules/tslib/tslib.es6.js] 10 KiB {module} [built]
  [./ConfigEditor.tsx] 1.5 KiB {module} [built]
  [./DataSource.ts] 6.67 KiB {module} [built]
  [./JsonPathQueryField.tsx] 492 bytes {module} [built]
  [./QueryEditor.tsx] 4.11 KiB {module} [built]
  [./VariableQueryEditor.tsx] 1.08 KiB {module} [built]
  [./api.ts] 2.7 KiB {module} [built]
  [./module.ts] 401 bytes {module} [built]
  [./types.ts] 108 bytes {module} [built]
  [@grafana/data] external "@grafana/data" 42 bytes {module} [built]
  [@grafana/ui] external "@grafana/ui" 42 bytes {module} [built]
  [emotion] external "emotion" 42 bytes {module} [built]
      + 282 hidden modules

  ERROR in D:/Code/grafana-plugins/grafana-jsonapi-datasource/src/DataSource.ts
  ERROR in D:/Code/grafana-plugins/grafana-jsonapi-datasource/src/DataSource.ts(38,34):
  TS2339: Property 'toPathArray' does not exist on type 'JSONPathType'.

  Trace: Build failed
      at D:\Code\grafana-plugins\grafana-jsonapi-datasource\node_modules\@grafana\toolkit\src\cli\utils\useSpinner.js:25:29
      at step (D:\Code\grafana-plugins\grafana-jsonapi-datasource\node_modules\@grafana\toolkit\node_modules\tslib\tslib.js:136:27)
      at Object.throw (D:\Code\grafana-plugins\grafana-jsonapi-datasource\node_modules\@grafana\toolkit\node_modules\tslib\tslib.js:117:57)
      at rejected (D:\Code\grafana-plugins\grafana-jsonapi-datasource\node_modules\@grafana\toolkit\node_modules\tslib\tslib.js:108:69)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
× Build failed
error Command failed with exit code 1.
```